### PR TITLE
In example, LLR would be positive if X is the leader and Y is the lagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Clearly, the argmax of the constrast is located around the correct value (lead_l
   <img src="figures/Figure_3.png" width="470">
 </p>
 
-We can also look at negative lags and define the LLR (standing for Lead/Lag Ratio) to measure the lead/lag relationships. If LLR > 1, then Y is the leader and X the lagger and vice versa for LLR <= 1. In our case, for the realization of our process (X,Y), we find LLR ~ 8.03.
+We can also look at negative lags and define the LLR (standing for Lead/Lag Ratio) to measure the lead/lag relationships. If LLR > 1, then X is the leader and Y the lagger and vice versa for LLR <= 1. In our case, for the realization of our process (X,Y), we find LLR ~ 8.03.
 
 <p align="center">
   <img src="figures/Figure_4.png" width="450">


### PR DESCRIPTION
I think the README has the LLR definition flipped. In the example, X is the leader and Y is the lagger, and positive LLR would indicate that. 

I think the reason you have it flipper here is that you flipped X and Y when you passed them into your `LeadLag` constructor: https://github.com/philipperemy/lead-lag/blob/d546b39c30ccc866bc39e3b3f3d8fc4742964abf/notebooks/realtime.py#L83

Let me know if this makes sense. 